### PR TITLE
적 유닛용 터렛 자동 설치 로직

### DIFF
--- a/Assets/Prefabs/Hatchery/Enemy/EnemyHatchery.prefab
+++ b/Assets/Prefabs/Hatchery/Enemy/EnemyHatchery.prefab
@@ -287,6 +287,7 @@ MonoBehaviour:
   turretSpotPrefab: {fileID: 7805221527644122040, guid: 4f2e3e7062a68774cb49b36ace5b64b9, type: 3}
   spotParent: {fileID: 2678450635999245614}
   initialSpotPosition: {x: -0.01, y: -0.05, z: 0}
+  buildInterval: 10
 --- !u!1 &3008611654472221743
 GameObject:
   m_ObjectHideFlags: 0
@@ -510,6 +511,58 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &3582472909035271502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8909566250721103195}
+  - component: {fileID: 6354976354925923486}
+  m_Layer: 0
+  m_Name: EnemyAI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8909566250721103195
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3582472909035271502}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3654876206274923325}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6354976354925923486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3582472909035271502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 310060d33a4e53945b29c7030cd65ca1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  turretBuildSequence:
+  - {fileID: 4330110605205189453, guid: 109568a72ac46544dacd50e4ea8534d9, type: 3}
+  - {fileID: 402038543466537056, guid: 73e2239f54db6ad4d81b8e88347cfe51, type: 3}
+  - {fileID: 7399804362714274945, guid: 45e44bd239ab3cb4ba72cd770e9566ea, type: 3}
+  maxTurrets: 2
+  buildTime: 30
+  initBuildTime: 10
+  increaseMaxTurretTime: 480
 --- !u!1 &6491014475347042980
 GameObject:
   m_ObjectHideFlags: 0
@@ -546,6 +599,7 @@ Transform:
   - {fileID: 2678450635999245614}
   - {fileID: 5499155780129235860}
   - {fileID: 176352023560064200}
+  - {fileID: 8909566250721103195}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &7663561264905457712

--- a/Assets/Scripts/Hatchery/EnemyAIController.cs
+++ b/Assets/Scripts/Hatchery/EnemyAIController.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 /// </summary>
 public class EnemyAIController : MonoBehaviour
 {
-    [Header("Turret Building Strategy")]
+    [Header("터렛 건설 전략(순서)")]
     [Tooltip("AI는 이 순서대로 터렛을 건설함..")]
     public List<GameObject> turretBuildSequence;
 
@@ -25,7 +25,7 @@ public class EnemyAIController : MonoBehaviour
     [Tooltip("게임 시작 후 첫 터렛 건설까지의 대기 시간 (초)")]
     public float initBuildTime = 10f;
 
-    [Header("Turret Capacity Upgrade")]
+    [Header("터렛 설치 최대 개수")]
     [Tooltip("첫 터렛 건설 후 밑의 시간이 지나면 최대 터렛 수 1 증가")]
     public float increaseMaxTurretTime = 480f; // 8 * 60 = 480 seconds
 

--- a/Assets/Scripts/Hatchery/EnemyAIController.cs
+++ b/Assets/Scripts/Hatchery/EnemyAIController.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// 적 AI 터렛 건설 관리
+/// </summary>
+public class EnemyAIController : MonoBehaviour
+{
+    [Header("Turret Building Strategy")]
+    [Tooltip("AI는 이 순서대로 터렛을 건설함..")]
+    public List<GameObject> turretBuildSequence;
+
+    [Tooltip("AI가 건설할 최대 터렛 수")]
+    public int maxTurrets = 2;
+
+    [Header("Timing")]
+    [Tooltip("터렛 건설을 시도하는 주기 (초)")]
+    public float buildTime = 30f;
+
+    [Tooltip("게임 시작 후 첫 터렛 건설까지의 대기 시간 (초)")]
+    public float initBuildTime = 10f;
+
+    [Header("Turret Capacity Upgrade")]
+    [Tooltip("첫 터렛 건설 후 밑의 시간이 지나면 최대 터렛 수 1 증가")]
+    public float increaseMaxTurretTime = 480f; // 8 * 60 = 480 seconds
+
+    private Queue<EnemyTurretSlot> turretQueue = new Queue<EnemyTurretSlot>();
+    private int turretSeq = 0;
+    private bool flag = false;
+
+    IEnumerator Start()
+    {
+        if (turretBuildSequence == null || turretBuildSequence.Count == 0)
+        {
+            Debug.LogWarning("AI의 터렛 건설 순서가 비어서 터렛 건설 AI가 비활성화", this);
+            yield break;
+        }
+
+        yield return new WaitForSeconds(initBuildTime);
+
+        // 주기적으로 터렛 건설/교체를 시도
+        while (true)
+        {
+            ExecuteNextBuildStep();
+            // 건설 주기만큼 대기
+            yield return new WaitForSeconds(buildTime);
+        }
+    }
+
+    /// <summary>
+    /// `turretBuildSequence` 순서대로 EnemyTurretSlot 컴포넌트를 가진 오브젝트에만 설치
+    /// 건설된 터렛 수가 최대치(현재 기본값 2개)에 도달하면 가장 오래된 터렛을 파괴, 재건설
+    /// </summary>
+    private void ExecuteNextBuildStep()
+    {
+        // 1. 최대 건설 수에 도달하면 가장 오래된 터렛을 제거
+        if (turretQueue.Count >= maxTurrets)
+        {
+            EnemyTurretSlot oldestSlot = turretQueue.Dequeue();
+            if (oldestSlot != null)
+            {
+                Debug.Log($"AI: 최대 터렛 수({maxTurrets})에 도달하여 가장 오래된 터렛이 설치된 '{oldestSlot.gameObject.name}' 슬롯의 터렛을 파괴", this);
+                oldestSlot.DestroyTurret();
+            }
+        }
+
+        // 2. 씬에 있는 모든 빈 적 터렛 슬롯을 찾기
+        var emptySlots = FindObjectsOfType<EnemyTurretSlot>()
+            .Where(slot => !slot.IsOccupied)
+            .ToList();
+
+        if (emptySlots.Count == 0)
+        {
+            Debug.Log("AI: 건설 가능한 빈 터렛 슬롯이 없습니다. 다음 주기에 다시 시도", this);
+            return;
+        }
+
+        // 3. 건설할 터렛을 turretBuildSequence에서 순서 가져옴
+        // 큐에서 순환
+        if (turretSeq >= turretBuildSequence.Count)
+        {
+            turretSeq = 0; // 처음부터 다시 시작
+        }
+        GameObject turretToBuild = turretBuildSequence[turretSeq];
+
+        // 4. 사용 가능한 슬롯 중 하나를 무작위로 선택
+        EnemyTurretSlot slotToBuildIn = emptySlots[Random.Range(0, emptySlots.Count)];
+
+        // 5. 터렛 건설
+        string turretNameToBuild = turretToBuild != null ? turretToBuild.name : "무작위 터렛";
+        Debug.Log($"AI가 동적으로 찾은 빈 슬롯 '{slotToBuildIn.gameObject.name}'에 순서에 따른 '{turretNameToBuild}' 건설을 시도", this);
+        slotToBuildIn.BuildTurretByAI(turretToBuild);
+
+        // 6. 건설된 터렛 정보를 큐에 추가 다음 인덱스 증가
+        turretQueue.Enqueue(slotToBuildIn);
+        turretSeq++;
+
+        // 7. 첫 터렛 건설 시, 필요한 프로세스들을 시작합니다.
+        if (!flag)
+        {
+            flag = true;
+
+            // 터렛 스팟 자동 건설 프로세스 시작
+            TurretSpotBuilder spotBuilder = FindObjectOfType<TurretSpotBuilder>();
+            if (spotBuilder != null)
+            {
+                spotBuilder.StartBuildingProcess();
+                Debug.Log("AI가 첫 터렛을 건설하여 터렛 스팟 자동 건설 시작", this);
+            }
+            else
+            {
+                Debug.LogWarning("씬에서 TurretSpotBuilder를 못 찾겠음..", this);
+            }
+
+            // 최대 터렛 수 증가 타이머 시작
+            if (increaseMaxTurretTime > 0)
+            {
+                StartCoroutine(IncreaseMaxTurretsAfterDelay());
+            }
+        }
+    }
+
+    /// <summary>
+    /// 지정된 시간(8분)이 지나면 최대 터렛 수를 1 증가시킵니다.
+    /// </summary>
+    private IEnumerator IncreaseMaxTurretsAfterDelay()
+    {
+        Debug.Log($"첫 터렛 건설. {increaseMaxTurretTime}초 후에 최대 터렛 수가 1 증가합니다.", this);
+        yield return new WaitForSeconds(increaseMaxTurretTime);
+        maxTurrets++;
+        Debug.Log($"시간이 경과하여 AI의 최대 터렛 수가 {maxTurrets}(으)로 증가했습니다.", this);
+    }
+}

--- a/Assets/Scripts/Hatchery/EnemyAIController.cs
+++ b/Assets/Scripts/Hatchery/EnemyAIController.cs
@@ -19,6 +19,9 @@ public class EnemyAIController : MonoBehaviour
     [Tooltip("터렛 건설을 시도하는 주기 (초)")]
     public float buildTime = 30f;
 
+    [Tooltip("AI가 터렛 스팟을 건설하는 주기 (초). 이 값은 TurretSpotBuilder로 전달됩니다.")]
+    public float spotBuildInterval = 10f;
+
     [Tooltip("게임 시작 후 첫 터렛 건설까지의 대기 시간 (초)")]
     public float initBuildTime = 10f;
 
@@ -106,7 +109,7 @@ public class EnemyAIController : MonoBehaviour
             TurretSpotBuilder spotBuilder = FindObjectOfType<TurretSpotBuilder>();
             if (spotBuilder != null)
             {
-                spotBuilder.StartBuildingProcess();
+                spotBuilder.StartBuildingProcess(spotBuildInterval);
                 Debug.Log("AI가 첫 터렛을 건설하여 터렛 스팟 자동 건설 시작", this);
             }
             else

--- a/Assets/Scripts/Hatchery/EnemyAIController.cs.meta
+++ b/Assets/Scripts/Hatchery/EnemyAIController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 310060d33a4e53945b29c7030cd65ca1

--- a/Assets/Scripts/Hatchery/EnemyTurretSlot.cs
+++ b/Assets/Scripts/Hatchery/EnemyTurretSlot.cs
@@ -10,10 +10,6 @@ public class EnemyTurretSlot : MonoBehaviour
     [Tooltip("이 슬롯에 건설 가능한 적 터렛 프리팹 목록")]
     public List<GameObject> enemyTurretPrefabs;
 
-    [Header("Visuals")]
-    [Tooltip("마우스 호버 시 표시될 시각적 효과 오브젝트")]
-    public GameObject hoverVisual;
-
     [Header("State (Runtime)")]
     [Tooltip("터렛이 장착되었는지 여부")]
     [SerializeField]
@@ -25,28 +21,20 @@ public class EnemyTurretSlot : MonoBehaviour
     private GameObject mountedTurret;
     public GameObject MountedTurret => mountedTurret;
 
-    void Start()
-    {
-        // 게임 시작 시 호버 효과를 비활성화
-        if (hoverVisual != null)
-        {
-            hoverVisual.SetActive(false);
-        }
-    }
-
-    // 테스트용 마우스 클릭으로 터렛 건설
-    private void OnMouseDown()
-    {
-        Debug.Log($"EnemyTurretSlot Clicked '{this.gameObject.name}'");
-        BuildRandomTurret();
-    }
-
     /// <summary>
     /// AI 컨트롤러 등 외부에서 호출하여 터렛을 건설하게 할 수 있는 public 메서드
     /// </summary>
-    public void BuildTurretByAI()
+    /// <param name="specificTurretPrefab">건설할 특정 터렛 프리팹. null이면 목록에서 무작위로 선택합니다.</param>
+    public void BuildTurretByAI(GameObject specificTurretPrefab = null)
     {
-        BuildRandomTurret();
+        if (specificTurretPrefab != null)
+        {
+            MountTurret(specificTurretPrefab);
+        }
+        else
+        {
+            BuildRandomTurret();
+        }
     }
 
     /// <summary>
@@ -100,16 +88,29 @@ public class EnemyTurretSlot : MonoBehaviour
             mountedTurret.transform.SetParent(this.transform.parent);
         }
 
-        // 터렛이 장착되었으므로 호버 효과를 비활성화
-        if (hoverVisual != null)
-        {
-            hoverVisual.SetActive(false);
-        }
-
         isOccupied = true;
         Debug.Log($"적 터렛 '{turretPrefab.name}'이(가) '{this.gameObject.name}'에 장착되었습니다.", this.gameObject);
 
         return true;
+    }
+
+    /// <summary>
+    /// 이 슬롯에 장착된 터렛을 파괴합니다. AI에 의해 호출됩니다.
+    /// </summary>
+    public void DestroyTurret()
+    {
+        if (!isOccupied || mountedTurret == null)
+        {
+            // 이미 비어있거나 터렛이 없는 경우(예: 플레이어에 의해 파괴됨), 상태만 정리하고 종료합니다.
+            isOccupied = false;
+            mountedTurret = null;
+            return;
+        }
+
+        Debug.Log($"'{gameObject.name}' 슬롯의 터렛 '{mountedTurret.name}'을(를) 파괴합니다.", this);
+        Destroy(mountedTurret);
+        mountedTurret = null;
+        isOccupied = false;
     }
 
     // 씬 뷰에서 터렛 슬롯 영역
@@ -117,22 +118,6 @@ public class EnemyTurretSlot : MonoBehaviour
     {
         Gizmos.color = isOccupied ? new Color(1f, 0.5f, 0f) : Color.magenta;
         Gizmos.DrawWireCube(transform.position, transform.lossyScale);
-    }
-
-    private void OnMouseEnter()
-    {
-        if (!isOccupied && hoverVisual != null)
-        {
-            hoverVisual.SetActive(true);
-        }
-    }
-
-    private void OnMouseExit()
-    {
-        if (hoverVisual != null)
-        {
-            hoverVisual.SetActive(false);
-        }
     }
 }
 

--- a/Assets/Scripts/Hatchery/TurretSlot.cs
+++ b/Assets/Scripts/Hatchery/TurretSlot.cs
@@ -122,7 +122,7 @@ public class TurretSlot : MonoBehaviour
     /// <summary>
     /// 슬롯에 장착된 터렛을 제거(판매)
     /// </summary>
-  
+
     private bool RemoveTurret()
     {
         if (!isOccupied)

--- a/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
+++ b/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
@@ -17,6 +17,9 @@ public class TurretSpotBuilder : MonoBehaviour
     [Tooltip("첫 번째 터렛 스팟이 생성될 위치 (spotParent 기준 로컬 좌표)")]
     public Vector3 initialSpotPosition = Vector3.zero;
 
+    [Tooltip("터렛 스팟을 추가로 건설하는 주기 (초)")]
+    public float buildInterval = 10f;
+
     private List<GameObject> _turretSpots = new List<GameObject>();
     private const int MAX_TURRET_SPOTS = 4;
     private bool _isBuildingProcessStarted = false;
@@ -30,7 +33,6 @@ public class TurretSpotBuilder : MonoBehaviour
             return;
         }
 
-        // spotParent가 지정되지 않았다면, 이 컴포넌트의 Transform을 부모로 사용합니다.
         Transform parent = spotParent != null ? spotParent : this.transform;
         if (spotParent == null)
         {
@@ -43,27 +45,26 @@ public class TurretSpotBuilder : MonoBehaviour
     }
 
     /// <summary>
-    /// 외부(예: 첫 터렛 건설 시)에서 호출하여 터렛 스팟 자동 건설 프로세스를 시작합니다.
+    /// 적 터렛 설치 AI에서 사용
     /// </summary>
     public void StartBuildingProcess()
     {
         if (_isBuildingProcessStarted) return;
         _isBuildingProcessStarted = true;
 
-        Debug.Log("첫 터렛 건설 신호를 받아, 1분마다 터렛 스팟 추가 건설을 시작합니다.");
+        Debug.Log($"첫 터렛 건설 후 {buildInterval}초마다 터렛 스팟 건설을 시작합니다.");
         StartCoroutine(BuildSpotsOverTime());
     }
 
     /// <summary>
-    /// 일정 시간(1분)마다 터렛 스팟을 추가로 건설하는 코루틴입니다.
+    /// 일정 시간(1분)마다 터렛 스팟을 추가로 건설
     /// </summary>
     private IEnumerator BuildSpotsOverTime()
     {
         // 최대 스팟 수에 도달할 때까지 반복합니다.
         while (_turretSpots.Count < MAX_TURRET_SPOTS)
         {
-            // 1분(60초) 대기합니다.
-            yield return new WaitForSeconds(5f);
+            yield return new WaitForSeconds(buildInterval);
 
             // BuildTurretSpot()은 내부적으로 최대 개수 체크를 하므로 여기서 호출만 하면 됩니다.
             BuildTurretSpot();

--- a/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
+++ b/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections;
 using UnityEngine;
 
 /// <summary>
@@ -18,6 +19,7 @@ public class TurretSpotBuilder : MonoBehaviour
 
     private List<GameObject> _turretSpots = new List<GameObject>();
     private const int MAX_TURRET_SPOTS = 4;
+    private bool _isBuildingProcessStarted = false;
 
     void Start()
     {
@@ -40,12 +42,33 @@ public class TurretSpotBuilder : MonoBehaviour
         Debug.Log($"<color=cyan>초기 터렛 스팟 '{initialSpot.name}' 생성 완료.</color>", initialSpot);
     }
 
-    private void Update()
+    /// <summary>
+    /// 외부(예: 첫 터렛 건설 시)에서 호출하여 터렛 스팟 자동 건설 프로세스를 시작합니다.
+    /// </summary>
+    public void StartBuildingProcess()
     {
-        if (Input.GetKeyDown(KeyCode.T))
+        if (_isBuildingProcessStarted) return;
+        _isBuildingProcessStarted = true;
+
+        Debug.Log("첫 터렛 건설 신호를 받아, 1분마다 터렛 스팟 추가 건설을 시작합니다.");
+        StartCoroutine(BuildSpotsOverTime());
+    }
+
+    /// <summary>
+    /// 일정 시간(1분)마다 터렛 스팟을 추가로 건설하는 코루틴입니다.
+    /// </summary>
+    private IEnumerator BuildSpotsOverTime()
+    {
+        // 최대 스팟 수에 도달할 때까지 반복합니다.
+        while (_turretSpots.Count < MAX_TURRET_SPOTS)
         {
+            // 1분(60초) 대기합니다.
+            yield return new WaitForSeconds(5f);
+
+            // BuildTurretSpot()은 내부적으로 최대 개수 체크를 하므로 여기서 호출만 하면 됩니다.
             BuildTurretSpot();
         }
+        Debug.Log("최대 터렛 스팟 수에 도달하여 추가 건설을 중단합니다.");
     }
 
     /// <summary>

--- a/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
+++ b/Assets/Scripts/Hatchery/TurretSpotBuilder.cs
@@ -17,10 +17,8 @@ public class TurretSpotBuilder : MonoBehaviour
     [Tooltip("첫 번째 터렛 스팟이 생성될 위치 (spotParent 기준 로컬 좌표)")]
     public Vector3 initialSpotPosition = Vector3.zero;
 
-    [Tooltip("터렛 스팟을 추가로 건설하는 주기 (초)")]
-    public float buildInterval = 10f;
-
     private List<GameObject> _turretSpots = new List<GameObject>();
+    private float _buildInterval = 10f; // AI 컨트롤러로부터 값을 받기 전의 기본값
     private const int MAX_TURRET_SPOTS = 4;
     private bool _isBuildingProcessStarted = false;
 
@@ -47,12 +45,13 @@ public class TurretSpotBuilder : MonoBehaviour
     /// <summary>
     /// 적 터렛 설치 AI에서 사용
     /// </summary>
-    public void StartBuildingProcess()
+    public void StartBuildingProcess(float intervalFromAI)
     {
         if (_isBuildingProcessStarted) return;
         _isBuildingProcessStarted = true;
+        _buildInterval = intervalFromAI;
 
-        Debug.Log($"첫 터렛 건설 후 {buildInterval}초마다 터렛 스팟 건설을 시작합니다.");
+        Debug.Log($"첫 터렛 건설 후 {_buildInterval}초마다 터렛 스팟 건설을 시작합니다.");
         StartCoroutine(BuildSpotsOverTime());
     }
 
@@ -64,7 +63,7 @@ public class TurretSpotBuilder : MonoBehaviour
         // 최대 스팟 수에 도달할 때까지 반복합니다.
         while (_turretSpots.Count < MAX_TURRET_SPOTS)
         {
-            yield return new WaitForSeconds(buildInterval);
+            yield return new WaitForSeconds(_buildInterval);
 
             // BuildTurretSpot()은 내부적으로 최대 개수 체크를 하므로 여기서 호출만 하면 됩니다.
             BuildTurretSpot();


### PR DESCRIPTION
EnemyAIController.cs 작성
- 적 터렛 건설 전략을 리스트화(리스트 목록을 순차적으로 돌며 터렛 건설)
- 최대 터렛 개수는 초기에 2개 -> Increase Max Turret Time이 지나면 +1(난이도 조절)
- 터렛 건설 타이밍은 첫 터렛 건설과 그 이후 추가 건설 타이밍으로 나눔(난이도 조절 가능)
- 추가로 터렛 스팟 건설 시간도 이 스크립트에서 수정 가능

https://github.com/user-attachments/assets/6349b857-2dda-4f91-a30a-fc7c0eb6787a

